### PR TITLE
Remove “settings.py(.sample)”

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@
 /.mypy_cache/
 /dist/
 mbdata.egg-info/
-settings.py
 venv/

--- a/settings.py.sample
+++ b/settings.py.sample
@@ -1,4 +1,0 @@
-DATABASE_URI = 'postgresql://musicbrainz:FIXME@127.0.0.1/musicbrainz'
-
-SOLR_URI = 'http://127.0.0.1:8983/solr/musicbrainz'
-


### PR DESCRIPTION
This is the settings file for `mbdata`, so much like mbslave.conf(.default) was removed from mbdata, settings.py(.sample) should probably be removed from mbslave. :)