### PR TITLE
Make windows-compatible, fix error on import, fix triggers

### DIFF
--- a/mbslave/replication.py
+++ b/mbslave/replication.py
@@ -587,8 +587,6 @@ def create_database(config: Config) -> None:
     cursor = db.cursor()
     cursor.execute(f"CREATE DATABASE {config.database.name} WITH OWNER {config.database.user}")
     cursor.execute(f"ALTER DATABASE {config.database.name} SET timezone TO 'UTC'")
-    if 'musicbrainz' not in config.schemas.ignored_schemas:
-        cursor.execute(f"ALTER DATABASE {config.database.name} SET search_path TO \"$USER\", {config.schemas.name('musicbrainz')}, public")
 
 
 def create_schemas(config: Config) -> None:

--- a/mbslave/replication.py
+++ b/mbslave/replication.py
@@ -260,7 +260,7 @@ def load_tar(source: str, fileobj: BytesIO, db, config, ignored_schemas, ignored
 
 
 def mbslave_import_main(config, args):
-    db = connect_db(config, superuser=True, set_search_path=False)
+    db = connect_db(config, superuser=True, set_search_path=True)
 
     for source in args.sources:
         with ExitStack() as exit_stack:

--- a/mbslave/replication.py
+++ b/mbslave/replication.py
@@ -608,7 +608,7 @@ def create_schemas(config: Config) -> None:
 
 
 def run_script(script: str) -> None:
-    subprocess.run(['bash', '-euxc', script], check=True)
+    p = subprocess.run(script, check=True, shell=True)
 
 
 def run_sql_script(name: str, superuser: bool = False) -> None:

--- a/mbslave/replication.py
+++ b/mbslave/replication.py
@@ -587,6 +587,8 @@ def create_database(config: Config) -> None:
     cursor = db.cursor()
     cursor.execute(f"CREATE DATABASE {config.database.name} WITH OWNER {config.database.user}")
     cursor.execute(f"ALTER DATABASE {config.database.name} SET timezone TO 'UTC'")
+    if 'musicbrainz' not in config.schemas.ignored_schemas:
+        cursor.execute(f"ALTER DATABASE {config.database.name} SET search_path TO \"$USER\", {config.schemas.name('musicbrainz')}, public")
 
 
 def create_schemas(config: Config) -> None:

--- a/mbslave/replication.py
+++ b/mbslave/replication.py
@@ -610,7 +610,7 @@ def create_schemas(config: Config) -> None:
 
 
 def run_script(script: str) -> None:
-    p = subprocess.run(script, check=True, shell=True)
+    subprocess.run(script, check=True, shell=True)
 
 
 def run_sql_script(name: str, superuser: bool = False) -> None:

--- a/mbslave/replication.py
+++ b/mbslave/replication.py
@@ -260,7 +260,7 @@ def load_tar(source: str, fileobj: BytesIO, db, config, ignored_schemas, ignored
 
 
 def mbslave_import_main(config, args):
-    db = config.database.connect_db(superuser=True, set_search_path=False)
+    db = connect_db(config, superuser=True, set_search_path=False)
 
     for source in args.sources:
         with ExitStack() as exit_stack:


### PR DESCRIPTION
The following is addressed by this PR:

### Make mbslave compatible with Windows (without WSL)
The problem: in the run_script function, the shell is (unnecessarily) hard-coded to `bash`. When run on Windows, this triggers the Windows subsystem for Linux that not everyone may have set up.

The solution: use the `shell=True` parameter of `subprocess.run` rather than hard-coding to `bash`.
This should not break anything (correct me if i'm wrong).

### fix https://github.com/acoustid/mbdata/issues/60
The problem: When importing, the call to connect to the database was wrong (connect_database is not defined).

The solution: Corrected the call like already suggested in that issue.

### Fix the triggers on `l_area_area` table
The problem: These triggers contain not fully-qualified references to table "link" in the `musicbrainz` schema.
That led, for me, to the data import failing on the l_area_area table because the table "link" was not found.

The solution: Added a command to set the postgres `search_path` to include the `musicbrainz` schema upon database creation (if this schema is not ignored).

---

If i should split the PR, let me know. But i felt uncomfortable making so many PRs with each of them having so little code changes.