### PR TITLE
❄️ Add flake.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /dist/
 mbdata.egg-info/
 venv/
+result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  pkgs,
+  python3,
+}:
+python3.pkgs.buildPythonPackage rec {
+  pname = "mbslave";
+  version = "29.1.0";
+  pyproject = true;
+
+  src = pkgs.fetchFromGitHub {
+    owner = "acoustid";
+    repo = "mbslave";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-XCj8Jt6uH3/cZDTxQYgkpiV4bc1Y+i/UccfNZVMZbAI=";
+  };
+  propagatedBuildInputs = with python3.pkgs; [
+    attrs
+    colorama
+    exceptiongroup
+    iniconfig
+    pluggy
+    prometheus-client
+    psycopg2
+    pyparsing
+    six
+    sqlparse
+    tomli
+    typing-extensions
+    poetry-core
+  ];
+
+  prePatch = ''
+    substituteInPlace pyproject.toml --replace 'prometheus-client = "^0.20.0"' 'prometheus-client = ">=0.20.0"'
+  '';
+
+  meta = with lib; {
+    description = "MusicBrainz Database Mirror";
+    homepage = "https://github.com/acoustid/mbslave";
+    changelog = "https://github.com/acoustid/mbslave/releases/tag/v${src.rev}";
+    license = licenses.mit;
+    mainProgram = "mbslave";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729265718,
+        "narHash": "sha256-4HQI+6LsO3kpWTYuVGIzhJs1cetFcwT7quWCk/6rqeo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ccc0c2126893dd20963580b6478d1a10a4512185",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "MusicBrainz Database Mirror ";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  } @ inputs:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+    in {
+      packages.default = pkgs.callPackage ./default.nix {};
+
+      #devShells.default = pkgs.mkShell {
+      #  buildInputs = [ pkgs.python310 ];
+      #};
+
+      apps.default = {
+        type = "app";
+        program = "${self.packages.${system}.default}/bin/mbslave";
+      };
+    });
+}


### PR DESCRIPTION
`mbslave` doesn't seem to be packaged for `nix` and running `pip` commands usually pollutes the system it's run on.
This change adds a `flake.nix` and  `default.nix` witch would allow all `nix` package manager users to simply run the command using(once merged in & nix flakes enabled):

```sh
nix run github:acoustid/mbslave
```

You can test it against my fork:

```sh
nix run github:master-kurosawa/mbslave
```

Also if possible it would be great if `prometheus-client` be updated to a newer version/lock file version made more forgiving. I had to patch it(in `prePatch`) to work with newer versions that are in `nixpkgs`.


If anyone would be interested `default.nix` should be good enough to submit upstream to nixpkgs(maybe remove the part that patches `prometheus-client`). 
I will do no such thing though.